### PR TITLE
Removing rxjs, moving konva, fixing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react-transition-group": "2.2.1",
     "redux": "3.7.2",
     "rimraf": "2.6.2",
-    "rxjs": "5.3.0",
     "source-map-loader": "0.2.1",
     "source-map-support": "0.5.0",
     "style-loader": "0.19.0",
@@ -57,9 +56,7 @@
     "tslint-loader": "3.5.3",
     "typescript": "2.5.3",
     "webpack": "3.6.0",
-    "webpack-dev-server": "2.9.1"
-  },
-  "dependencies": {
+    "webpack-dev-server": "2.9.1",
     "konva": "^2.1.7"
   }
 }

--- a/src/app/shapes/ShapesLibraryPlugin.ts
+++ b/src/app/shapes/ShapesLibraryPlugin.ts
@@ -53,11 +53,10 @@ export class ShapesLibraryPlugin implements IShapesLibraryPlugin {
         return this.addShape("Line", (name) => new Line(name, x1, y1, x2, y2));
     }
     
-    public addImage(imageName: string): string {
-        const name = this.generateName("Image");
+    public addImage(): string {
+        throw new Error("Not Implemented Yet");
         //TODO
         //return this.addShape("Image", (name) => new Image(name, ...))
-        return name;
     }
 
     public addText(text: string): string {


### PR DESCRIPTION
rxjs wasn't used, konva moved with the other dependencies, and now addImage() throws an error to get rid of the build error.